### PR TITLE
QuestDB loader script - health check

### DIFF
--- a/scripts/load/load_questdb.sh
+++ b/scripts/load/load_questdb.sh
@@ -10,12 +10,13 @@ fi
 # Load parameters - common
 DATA_FILE_NAME=${DATA_FILE_NAME:-influx-data.gz}
 DATABASE_PORT=${DATABASE_PORT:-9000}
+DATABASE_HEALTH_PORT=${DATABASE_HEALTH_PORT:-9003}
 ILP_PORT=${ILP_PORT:-9009}
 
 EXE_DIR=${EXE_DIR:-$(dirname $0)}
 source ${EXE_DIR}/load_common.sh
 
-until curl http://${DATABASE_HOST}:${DATABASE_PORT}/ping 2>/dev/null; do
+until curl http://${DATABASE_HOST}:${DATABASE_HEALTH_PORT}/ping 2>/dev/null; do
     echo "Waiting for QuestDB"
     sleep 1
 done


### PR DESCRIPTION
Minor improvement to loader script to point to health check server.

Currently, we get:

```bash
PATH=${PATH}:~/tmp/go/bin NUM_WORKERS=1 ./scripts/load/load_questdb.sh
Bulk loading file /tmp/bulk_data/influx-data.gz
+ curl http://localhost:9000/ping
Not Found
```

on this branch:

```bash
PATH=${PATH}:~/tmp/go/bin NUM_WORKERS=1 ./scripts/load/load_questdb.sh
Bulk loading file /tmp/bulk_data/influx-data.gz
+ curl http://localhost:9003/ping
+ curl -X GET 'http://localhost:9000/exec?query=drop%20table%20cpu'
```
