### PR TITLE
Fix cpu-max-all query generation for QuestDB, Akumuli, TimeStream and CrateDB

### DIFF
--- a/cmd/tsbs_generate_queries/databases/akumuli/devops.go
+++ b/cmd/tsbs_generate_queries/databases/akumuli/devops.go
@@ -70,9 +70,11 @@ type tsdbAggregateAllQuery struct {
 // SELECT minute, max(metric1), ..., max(metricN)
 // FROM cpu
 // WHERE
-// 		(hostname = '$HOSTNAME_1' OR ... OR hostname = '$HOSTNAME_N')
-// 	AND time >= '$HOUR_START'
-// 	AND time < '$HOUR_END'
+//
+//		(hostname = '$HOSTNAME_1' OR ... OR hostname = '$HOSTNAME_N')
+//	AND time >= '$HOUR_START'
+//	AND time < '$HOUR_END'
+//
 // GROUP BY minute
 // ORDER BY minute ASC
 //
@@ -176,17 +178,19 @@ func (d *Devops) HighCPUForHosts(qi query.Query, nHosts int) {
 // SELECT MAX(metric1), ..., MAX(metricN)
 // FROM cpu
 // WHERE
-// 		(hostname = '$HOSTNAME_1' OR ... OR hostname = '$HOSTNAME_N')
-// 		AND time >= '$HOUR_START'
-// 		AND time < '$HOUR_END'
+//
+//	(hostname = '$HOSTNAME_1' OR ... OR hostname = '$HOSTNAME_N')
+//	AND time >= '$HOUR_START'
+//	AND time < '$HOUR_END'
+//
 // GROUP BY hour
 // ORDER BY hour
 //
 // Resultsets:
 // cpu-max-all-1
 // cpu-max-all-8
-func (d *Devops) MaxAllCPU(qi query.Query, nHosts int) {
-	interval := d.Interval.MustRandWindow(devops.MaxAllDuration)
+func (d *Devops) MaxAllCPU(qi query.Query, nHosts int, duration time.Duration) {
+	interval := d.Interval.MustRandWindow(duration)
 	hostnames, err := d.GetRandomHosts(nHosts)
 	panicIfErr(err)
 	startTimestamp := interval.StartUnixNano()

--- a/cmd/tsbs_generate_queries/databases/cratedb/devops.go
+++ b/cmd/tsbs_generate_queries/databases/cratedb/devops.go
@@ -28,7 +28,8 @@ const hostnameField = "tags['hostname']"
 // a set of column idents.
 //
 // For instance:
-//      max(cpu_time) AS max_cpu_time
+//
+//	max(cpu_time) AS max_cpu_time
 func (d *Devops) getSelectAggClauses(aggFunc string, idents []string) []string {
 	selectAggClauses := make([]string, len(idents))
 	for i, ident := range idents {
@@ -44,8 +45,8 @@ func (d *Devops) getSelectAggClauses(aggFunc string, idents []string) []string {
 // Queries:
 // cpu-max-all-1
 // cpu-max-all-8
-func (d *Devops) MaxAllCPU(qi query.Query, nHosts int) {
-	interval := d.Interval.MustRandWindow(devops.MaxAllDuration)
+func (d *Devops) MaxAllCPU(qi query.Query, nHosts int, duration time.Duration) {
+	interval := d.Interval.MustRandWindow(duration)
 	selectClauses := d.getSelectAggClauses("max", devops.GetAllCPUMetrics())
 	hosts, err := d.GetRandomHosts(nHosts)
 	panicIfErr(err)

--- a/cmd/tsbs_generate_queries/databases/cratedb/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/cratedb/devops_test.go
@@ -85,7 +85,7 @@ func TestDevopsMaxAllCPUQuery(t *testing.T) {
 		)}
 
 	got := &query.CrateDB{}
-	d.MaxAllCPU(got, 2)
+	d.MaxAllCPU(got, 2, devops.MaxAllDuration)
 
 	if !reflect.DeepEqual(want.SqlQuery, got.SqlQuery) {
 		t.Errorf("incorrect sql query:\ngot: %s\n want:\n %s",

--- a/cmd/tsbs_generate_queries/databases/questdb/devops.go
+++ b/cmd/tsbs_generate_queries/databases/questdb/devops.go
@@ -26,7 +26,8 @@ type Devops struct {
 // a set of column idents.
 //
 // For instance:
-//      max(cpu_time) AS max_cpu_time
+//
+//	max(cpu_time) AS max_cpu_time
 func (d *Devops) getSelectAggClauses(aggFunc string, idents []string) []string {
 	selectAggClauses := make([]string, len(idents))
 	for i, ident := range idents {
@@ -42,8 +43,8 @@ func (d *Devops) getSelectAggClauses(aggFunc string, idents []string) []string {
 // Queries:
 // cpu-max-all-1
 // cpu-max-all-8
-func (d *Devops) MaxAllCPU(qi query.Query, nHosts int) {
-	interval := d.Interval.MustRandWindow(devops.MaxAllDuration)
+func (d *Devops) MaxAllCPU(qi query.Query, nHosts int, duration time.Duration) {
+	interval := d.Interval.MustRandWindow(duration)
 	selectClauses := d.getSelectAggClauses("max", devops.GetAllCPUMetrics())
 	hosts, err := d.GetRandomHosts(nHosts)
 	panicIfErr(err)

--- a/cmd/tsbs_generate_queries/databases/questdb/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/questdb/devops_test.go
@@ -129,7 +129,7 @@ func TestMaxAllCPU(t *testing.T) {
 
 	testFunc := func(d *Devops, c testCase) query.Query {
 		q := d.GenerateEmptyQuery()
-		d.MaxAllCPU(q, c.input)
+		d.MaxAllCPU(q, c.input, devops.MaxAllDuration)
 		return q
 	}
 

--- a/cmd/tsbs_generate_queries/databases/timestream/devops.go
+++ b/cmd/tsbs_generate_queries/databases/timestream/devops.go
@@ -175,8 +175,8 @@ func (d *Devops) GroupByTimeAndPrimaryTag(qi query.Query, numMetrics int) {
 // FROM cpu WHERE (hostname = '$HOSTNAME_1' OR ... OR hostname = '$HOSTNAME_N')
 // AND time >= '$HOUR_START' AND time < '$HOUR_END'
 // GROUP BY hour ORDER BY hour
-func (d *Devops) MaxAllCPU(qi query.Query, nHosts int) {
-	interval := d.Interval.MustRandWindow(devops.MaxAllDuration)
+func (d *Devops) MaxAllCPU(qi query.Query, nHosts int, duration time.Duration) {
+	interval := d.Interval.MustRandWindow(duration)
 
 	metrics := devops.GetAllCPUMetrics()
 	selectClauses := d.getSelectClausesAggMetrics("max", metrics)

--- a/cmd/tsbs_generate_queries/databases/timestream/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/timestream/devops_test.go
@@ -2,12 +2,13 @@ package timestream
 
 import (
 	"fmt"
-	"github.com/andreyvit/diff"
-	"github.com/timescale/tsbs/pkg/query"
 	"math/rand"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/andreyvit/diff"
+	"github.com/timescale/tsbs/pkg/query"
 
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
 )
@@ -322,7 +323,7 @@ func TestMaxAllCPU(t *testing.T) {
 	d := dq.(*Devops)
 
 	q := d.GenerateEmptyQuery()
-	d.MaxAllCPU(q, 1)
+	d.MaxAllCPU(q, 1, devops.MaxAllDuration)
 	verifyQuery(t, q, expectedHumanLabel, expectedHumanDesc, expectedTable, expectedSQLQuery)
 }
 

--- a/go.sum
+++ b/go.sum
@@ -902,6 +902,7 @@ github.com/timescale/promscale v0.0.0-20201006153045-6a66a36f5c84/go.mod h1:rkhy
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tklauser/go-sysconf v0.3.5 h1:uu3Xl4nkLzQfXNsWn15rPc/HQCJKObbt1dKJeWp3vU4=
 github.com/tklauser/go-sysconf v0.3.5/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=
+github.com/tklauser/numcpus v0.2.2 h1:oyhllyrScuYI6g+h/zUvNXNp1wy7x8qQy3t/piefldA=
 github.com/tklauser/numcpus v0.2.2/go.mod h1:x3qojaO3uyYt0i56EW/VUYs7uBvdl2fkfZFu0T9wgjM=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
Upstream counterpart: https://github.com/timescale/tsbs/pull/220