### PR TITLE
Removed QuestDB: IoT from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ cases are implemented for each database:
 |CrateDB|X||
 |InfluxDB|X|X|
 |MongoDB|X|
-|QuestDB|X|X
+|QuestDB|X|
 |SiriDB|X|
 |TimescaleDB|X|X|
 |Timestream|X||


### PR DESCRIPTION
The TSBS implementation for QuestDB currently only supports the dev-ops use case, but not the IoT use case. 
This should be reflected in the README to avoid confusion