### PR TITLE
Add authentication and TLS support for QuestDB

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.20
 
     - name: Test
       run: go test -v -race ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,12 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.20
+        go-version: '1.20'
 
     - name: Test
       run: go test -v -race ./...

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .idea
 .vscode
 *~
+/bin
 
 # High Dynamic Range (HDR) Histogram files
 *.hdr

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Build stage
-FROM golang:1.13.1-alpine AS builder
+FROM golang:1.20.8-alpine AS builder
 WORKDIR /tsbs
 COPY ./ ./
 RUN apk update && apk add --no-cache git
 RUN go mod download && go install ./...
 
 # Final stage
-FROM alpine:3.8.5
+FROM alpine:3.18
 RUN apk update && apk add --no-cache bash
 COPY --from=builder /go/bin /
 COPY --from=builder /tsbs/scripts /

--- a/README.md
+++ b/README.md
@@ -92,14 +92,15 @@ cases are implemented for each database:
 |CrateDB|X||
 |InfluxDB|X|X|
 |MongoDB|X|
-|QuestDB|X|X
+|QuestDB|X|X²|
 |SiriDB|X|
 |TimescaleDB|X|X|
 |Timestream|X||
-|VictoriaMetrics|X²||
+|VictoriaMetrics|X³||
 
 ¹ Does not support the `groupby-orderby-limit` query
-² Does not support the `groupby-orderby-limit`, `lastpoint`, `high-cpu-1`, `high-cpu-all` queries
+² Supports ingestion only
+³ Does not support the `groupby-orderby-limit`, `lastpoint`, `high-cpu-1`, `high-cpu-all` queries
 
 ## What the TSBS tests
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Time Series Benchmark Suite (TSBS)
+
+This is a fork of https://github.com/timescale/tsbs by Timescale. Read
+[this post](https://questdb.io/blog/optimizing-optimizer-time-series-benchmark-suite/)
+to understand why we (QuestDB) created it.
+
 This repo contains code for benchmarking several time series databases,
 including TimescaleDB, MongoDB, InfluxDB, CrateDB and Cassandra.
 This code is based on a fork of work initially made public by InfluxDB
@@ -49,6 +54,7 @@ one host in the dataset and the number of different hosts generated is
 defined by the `scale` flag (see below).
 
 ### Internet of Things (IoT)
+
 The second use case is meant to simulate the data load in an IoT
 environment. This use case simulates data streaming from a set of trucks
 belonging to a fictional trucking company. This use case simulates

--- a/cmd/tsbs_generate_queries/databases/influx/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/influx/devops_test.go
@@ -60,21 +60,22 @@ func TestDevopsGetHostWhereString(t *testing.T) {
 		{
 			desc:   "single host",
 			nHosts: 1,
-			want:   "(hostname = 'host_1')",
+			want:   "(hostname = 'host_5')",
 		},
 		{
 			desc:   "multi host (2)",
 			nHosts: 2,
-			want:   "(hostname = 'host_7' or hostname = 'host_9')",
+			want:   "(hostname = 'host_5' or hostname = 'host_9')",
 		},
 		{
 			desc:   "multi host (3)",
 			nHosts: 3,
-			want:   "(hostname = 'host_1' or hostname = 'host_8' or hostname = 'host_5')",
+			want:   "(hostname = 'host_5' or hostname = 'host_9' or hostname = 'host_3')",
 		},
 	}
 
 	for _, c := range cases {
+		rand.Seed(123)
 		t.Run(c.desc, func(t *testing.T) {
 			b := BaseGenerator{}
 			dq, err := b.NewDevops(time.Now(), time.Now(), 10)
@@ -88,7 +89,6 @@ func TestDevopsGetHostWhereString(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestDevopsGetSelectClausesAggMetrics(t *testing.T) {

--- a/cmd/tsbs_load_questdb/creator.go
+++ b/cmd/tsbs_load_questdb/creator.go
@@ -1,40 +1,19 @@
 package main
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/url"
-	"strings"
 	"time"
 )
 
 type dbCreator struct {
-	questdbRESTEndPoint string
 }
 
 func (d *dbCreator) Init() {
-	d.questdbRESTEndPoint = questdbRESTEndPoint
+	// no-op
 }
 
 func (d *dbCreator) DBExists(dbName string) bool {
-	r, err := execQuery(questdbRESTEndPoint, "SHOW TABLES")
-	if err != nil {
-		panic(fmt.Errorf("fatal error, failed to query questdb: %s", err))
-	}
-	for i, v := range r.Dataset {
-		if i >= 0 && v[0] == "cpu" {
-			panic(fmt.Errorf("fatal error, cpu table already exists"))
-		}
-	}
-	// Create minimal table with o3 params
-	//        r, err = execQuery(questdbRESTEndPoint, "CREATE TABLE cpu (hostname SYMBOL, region SYMBOL, datacenter SYMBOL, rack SYMBOL, os SYMBOL, arch SYMBOL, team SYMBOL, service SYMBOL, service_version SYMBOL, service_environment SYMBOL, usage_user LONG, usage_system LONG, usage_idle LONG, usage_nice LONG, usage_iowait LONG, usage_irq LONG, usage_softirq LONG, usage_steal LONG, usage_guest LONG, usage_guest_nice LONG, timestamp TIMESTAMP) timestamp(timestamp) PARTITION BY DAY WITH o3MaxUncommittedRows=500000, o3CommitHysteresis=300s")
-	//        if err != nil {
-	//          panic(fmt.Errorf("fatal error, failed to create cpu table: %s", err))
-	//        }
-
+	// We don't really care if the table already exists,
+	// especially when dedup is configured.
 	return false
 }
 
@@ -45,42 +24,4 @@ func (d *dbCreator) RemoveOldDB(dbName string) error {
 func (d *dbCreator) CreateDB(dbName string) error {
 	time.Sleep(time.Second)
 	return nil
-}
-
-type QueryResponseColumns struct {
-	Name string
-	Type string
-}
-
-type QueryResponse struct {
-	Query   string
-	Columns []QueryResponseColumns
-	Dataset [][]interface{}
-	Count   int
-	Error   string
-}
-
-func execQuery(uriRoot string, query string) (QueryResponse, error) {
-	var qr QueryResponse
-	if strings.HasSuffix(uriRoot, "/") {
-		uriRoot = uriRoot[:len(uriRoot)-1]
-	}
-	uriRoot = uriRoot + "/exec?query=" + url.QueryEscape(query)
-	resp, err := http.Get(uriRoot)
-	if err != nil {
-		return qr, err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return qr, err
-	}
-	err = json.Unmarshal(body, &qr)
-	if err != nil {
-		return qr, err
-	}
-	if qr.Error != "" {
-		return qr, errors.New(qr.Error)
-	}
-	return qr, nil
 }

--- a/cmd/tsbs_load_questdb/main.go
+++ b/cmd/tsbs_load_questdb/main.go
@@ -23,8 +23,10 @@ import (
 
 // Program option vars:
 var (
-	questdbRESTEndPoint string
-	questdbILPBindTo    string
+	questdbILPBindTo string
+	useTLS           bool
+	authTokenId      string
+	authToken        string
 )
 
 // Global vars
@@ -53,6 +55,9 @@ func init() {
 	pflag.CommandLine.Int64("seed", 0, "PRNG seed (default: 0, which uses the current timestamp)")
 	pflag.CommandLine.String("insert-intervals", "", "Time to wait between each insert, default '' => all workers insert ASAP. '1,2' = worker 1 waits 1s between inserts, worker 2 and others wait 2s")
 	pflag.CommandLine.Bool("hash-workers", false, "Whether to consistently hash insert data to the same workers (i.e., the data for a particular host always goes to the same worker)")
+	pflag.CommandLine.Bool("tls", false, "Whether to use TLS encryption for database connection. The certificate check is disabled, so the client will trust any server")
+	pflag.CommandLine.String("ilp-auth-id", "", "ILP authentication token id")
+	pflag.CommandLine.String("ilp-auth-token", "", "ILP authentication token")
 	target.TargetSpecificFlags("", pflag.CommandLine)
 	pflag.Parse()
 
@@ -66,8 +71,10 @@ func init() {
 		panic(fmt.Errorf("unable to decode config: %s", err))
 	}
 
-	questdbRESTEndPoint = viper.GetString("url")
 	questdbILPBindTo = viper.GetString("ilp-bind-to")
+	useTLS = viper.GetBool("tls")
+	authTokenId = viper.GetString("ilp-auth-id")
+	authToken = viper.GetString("ilp-auth-token")
 	config.HashWorkers = false
 	config.NoFlowControl = true
 	loader = load.GetBenchmarkRunner(config)

--- a/cmd/tsbs_load_questdb/main.go
+++ b/cmd/tsbs_load_questdb/main.go
@@ -56,8 +56,8 @@ func init() {
 	pflag.CommandLine.String("insert-intervals", "", "Time to wait between each insert, default '' => all workers insert ASAP. '1,2' = worker 1 waits 1s between inserts, worker 2 and others wait 2s")
 	pflag.CommandLine.Bool("hash-workers", false, "Whether to consistently hash insert data to the same workers (i.e., the data for a particular host always goes to the same worker)")
 	pflag.CommandLine.Bool("tls", false, "Whether to use TLS encryption for database connection. The certificate check is disabled, so the client will trust any server")
-	pflag.CommandLine.String("ilp-auth-id", "", "ILP authentication token id")
-	pflag.CommandLine.String("ilp-auth-token", "", "ILP authentication token")
+	pflag.CommandLine.String("auth-id", "", "ILP authentication token id")
+	pflag.CommandLine.String("auth-token", "", "ILP authentication token")
 	target.TargetSpecificFlags("", pflag.CommandLine)
 	pflag.Parse()
 
@@ -73,8 +73,8 @@ func init() {
 
 	questdbILPBindTo = viper.GetString("ilp-bind-to")
 	useTLS = viper.GetBool("tls")
-	authTokenId = viper.GetString("ilp-auth-id")
-	authToken = viper.GetString("ilp-auth-token")
+	authTokenId = viper.GetString("auth-id")
+	authToken = viper.GetString("auth-token")
 	config.HashWorkers = false
 	config.NoFlowControl = true
 	loader = load.GetBenchmarkRunner(config)

--- a/cmd/tsbs_load_questdb/process.go
+++ b/cmd/tsbs_load_questdb/process.go
@@ -1,32 +1,98 @@
 package main
 
 import (
-	"fmt"
+	"bufio"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/base64"
+	"math/big"
 	"net"
 
 	"github.com/timescale/tsbs/pkg/targets"
 )
 
-// allows for testing
-var printFn = fmt.Printf
-
 type processor struct {
-	ilpConn (*net.TCPConn)
+	ilpConn net.Conn
 }
 
-func (p *processor) Init(numWorker int, _, _ bool) {
-	tcpAddr, err := net.ResolveTCPAddr("tcp4", questdbILPBindTo)
-	if err != nil {
-		fatal("Failed to resolve %s: %s\n", questdbILPBindTo, err.Error())
+func (p *processor) Init(numWorker int, doLoad, _ bool) {
+	if !doLoad {
+		return
 	}
-	p.ilpConn, err = net.DialTCP("tcp", nil, tcpAddr)
+
+	var (
+		d    net.Dialer
+		key  *ecdsa.PrivateKey
+		conn net.Conn
+		err  error
+	)
+
+	if authTokenId != "" && authToken != "" {
+		keyRaw, err := base64.RawURLEncoding.DecodeString(authToken)
+		if err != nil {
+			fatal("failed to decode auth key: %v", err)
+		}
+		key = new(ecdsa.PrivateKey)
+		key.PublicKey.Curve = elliptic.P256()
+		key.PublicKey.X, key.PublicKey.Y = key.PublicKey.Curve.ScalarBaseMult(keyRaw)
+		key.D = new(big.Int).SetBytes(keyRaw)
+	}
+
+	ctx := context.Background()
+	if useTLS {
+		config := &tls.Config{}
+		config.InsecureSkipVerify = true
+		conn, err = tls.DialWithDialer(&d, "tcp", questdbILPBindTo, config)
+	} else {
+		conn, err = d.DialContext(ctx, "tcp", questdbILPBindTo)
+	}
 	if err != nil {
 		fatal("Failed connect to %s: %s\n", questdbILPBindTo, err.Error())
 	}
+
+	if key != nil {
+		_, err = conn.Write([]byte(authTokenId + "\n"))
+		if err != nil {
+			fatal("failed to write key id: %v", err)
+		}
+
+		reader := bufio.NewReader(conn)
+		raw, err := reader.ReadBytes('\n')
+		if len(raw) < 2 {
+			fatal("empty challenge response from server: %v", err)
+		}
+		// Remove the `\n` in the last position.
+		raw = raw[:len(raw)-1]
+		if err != nil {
+			fatal("failed to read challenge response from server: %v", err)
+		}
+
+		// Hash the challenge with sha256.
+		hash := crypto.SHA256.New()
+		hash.Write(raw)
+		hashed := hash.Sum(nil)
+
+		stdSig, err := ecdsa.SignASN1(rand.Reader, key, hashed)
+		if err != nil {
+			fatal("failed to sign challenge using auth key: %v", err)
+		}
+		_, err = conn.Write([]byte(base64.StdEncoding.EncodeToString(stdSig) + "\n"))
+		if err != nil {
+			fatal("failed to write signed challenge: %v", err)
+		}
+	}
+
+	p.ilpConn = conn
 }
 
-func (p *processor) Close(_ bool) {
-	defer p.ilpConn.Close()
+func (p *processor) Close(doLoad bool) {
+	if doLoad {
+		p.ilpConn.Close()
+	}
 }
 
 func (p *processor) ProcessBatch(b targets.Batch, doLoad bool) (uint64, uint64) {
@@ -34,8 +100,7 @@ func (p *processor) ProcessBatch(b targets.Batch, doLoad bool) (uint64, uint64) 
 
 	// Write the batch: try until backoff is not needed.
 	if doLoad {
-		var err error
-		_, err = p.ilpConn.Write(batch.buf.Bytes())
+		_, err := p.ilpConn.Write(batch.buf.Bytes())
 		if err != nil {
 			fatal("Error writing: %s\n", err.Error())
 		}

--- a/cmd/tsbs_load_questdb/process_test.go
+++ b/cmd/tsbs_load_questdb/process_test.go
@@ -177,14 +177,13 @@ func mockServerStart(cfg mockServerConfig) *mockServer {
 				}
 
 				for {
-					rc, err := conn.Read(data)
+					_, err := conn.Read(data)
 					if err != nil {
 						if err != io.EOF {
 							fatal("failed to read from connection: ", err.Error())
 						}
 						return
 					}
-					fmt.Println(conn, " read ", rc)
 				}
 			}()
 		}

--- a/cmd/tsbs_load_questdb/process_test.go
+++ b/cmd/tsbs_load_questdb/process_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"sync"
 	"testing"
@@ -12,21 +14,129 @@ import (
 	"github.com/timescale/tsbs/pkg/data"
 )
 
-func emptyLog(_ string, _ ...interface{}) (int, error) {
-	return 0, nil
-}
+const testTlsCertificate = `-----BEGIN CERTIFICATE-----
+MIIFETCCAvkCFAjRNUAVvcoaUkmcOSVKxT8cVI1sMA0GCSqGSIb3DQEBCwUAMEUx
+CzAJBgNVBAYTAkJHMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRl
+cm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMjMwOTI2MDcwNDQwWhcNMjQwOTI1MDcw
+NDQwWjBFMQswCQYDVQQGEwJCRzETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UE
+CgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIICIjANBgkqhkiG9w0BAQEFAAOC
+Ag8AMIICCgKCAgEAlVIxz9icPSBzW72xeDtoaAGnWwlBQGR9ekAOLZGOSZpihrES
+W0HdvaQberJqjPWEVhfKGyUPXhvoEFOkq9r5hEskehJZ89u8qHbF1RS9cVECmcil
+AOYaooC1pleZd0gqiClt1oFczJBzSL4qOsJS9AM9FGTYO2hZTegPR0Yl69OFGP5V
+DAUCEmbfipGaGenYfIe90l9e8tvMh446PIyHKIivN8fP1hBDgY7V2qNVneAqzWyG
+Yv36sK3Noeoi1qbGEdAqlZcB29wRz41mRNsRHsn4kZbMPPUPbtbDhciIaDgz7EVo
+502XTPr9KJcwGfpVPhV4/O4Ccs7cM9bJqL/dmtC+cPEgWJYJF/9H8QzCaODyd/rK
+1TuCxMDHYnYu018hgzdWstdZsZL0o6/qbbVvn4OpTGA4Pqk5KEfawxHiZicNEslP
+4hWb26/Fvei2pnidZ+n8pdUIqPh+TpCdYlecbcXTV9oPJSCijDjr7ADKg7y14kSF
+vZ1eHHhj/8r5f/KPDPPwmCxwuoiJQ0rnoaJ/gEt0k3XrSNveYLK88RMHExm07ruV
+JxLOHz+q6pDrwdMoDS04wT00Q2lscSsEmBqdwiClep8mB+cdwEzPMatt08bQ8iQm
+JWDIlzU/ZBkpeaNQA9W+rNGWwuD1LikS7wtZDi/tPaEcJQYmCFkzKymOyvECAwEA
+ATANBgkqhkiG9w0BAQsFAAOCAgEABsivUk0dJEZTONdt1B9SfdMHmHiW/PdPyaEX
+i9Jg4mw7OfdT7mI8sIqfLtn15WRylmtEOnQkVDRRvQZtP2V1PXh66EmxQm3uXWb9
+Uk65Caz7dDmz/fYMt37cgO780v6IoDMy43MCbgKgvGvo6TicmoP/PaJmSk7k+HmA
+PdCsTilIoiHlg+nDjW2oWMqhRdJ3cjk6CMsg5UTncorD7/EuwkFyYC6o8YJDdmwI
+F9o/8KQOcSS4JIcsyrnDxyVHZL7wKnkSWfENl5dFr1FviSiVBWPkdXkv948zQWfA
+pzUgD4q2gRGNWuEoDPD0JNUo2ID6YAwHby40RB43FqM42BqswFnAkz+IwC7vbkHU
+7kt4HuaSU2CeuSh3dGDy4NAYhRuDiBZjMEb9p97/DnPKmE0qCueBPf50momHfD9t
+y9uKc59wCDCEaGypHgyCrrKe3fqcW6kvL0HTxlC1j9zWA16xhF8O5HObKGdCVkjM
+RY2LDpFlgOKmjSgUTBNgPI0boMgJSowEl7h7crtJ+gdwQeGdKcPShIjwU29CrWee
+X0mrhAZejQ+QL6O1vWcWix93AFHujw7TQ5xGNyGa9ljhbAEwSEtlsiKhFE1KUe3U
+ZzmgzGSOpl/Fq0p5jT5o7b8phRabGK5Kg6X1UNOFQgSCpFyxaATUqPDwqIeja8Qs
+ljLMnC8=
+-----END CERTIFICATE-----
+`
+const testTlsPrivateKey = `-----BEGIN PRIVATE KEY-----
+MIIJQwIBADANBgkqhkiG9w0BAQEFAASCCS0wggkpAgEAAoICAQCVUjHP2Jw9IHNb
+vbF4O2hoAadbCUFAZH16QA4tkY5JmmKGsRJbQd29pBt6smqM9YRWF8obJQ9eG+gQ
+U6Sr2vmESyR6Elnz27yodsXVFL1xUQKZyKUA5hqigLWmV5l3SCqIKW3WgVzMkHNI
+vio6wlL0Az0UZNg7aFlN6A9HRiXr04UY/lUMBQISZt+KkZoZ6dh8h73SX17y28yH
+jjo8jIcoiK83x8/WEEOBjtXao1Wd4CrNbIZi/fqwrc2h6iLWpsYR0CqVlwHb3BHP
+jWZE2xEeyfiRlsw89Q9u1sOFyIhoODPsRWjnTZdM+v0olzAZ+lU+FXj87gJyztwz
+1smov92a0L5w8SBYlgkX/0fxDMJo4PJ3+srVO4LEwMdidi7TXyGDN1ay11mxkvSj
+r+pttW+fg6lMYDg+qTkoR9rDEeJmJw0SyU/iFZvbr8W96LameJ1n6fyl1Qio+H5O
+kJ1iV5xtxdNX2g8lIKKMOOvsAMqDvLXiRIW9nV4ceGP/yvl/8o8M8/CYLHC6iIlD
+Suehon+AS3STdetI295gsrzxEwcTGbTuu5UnEs4fP6rqkOvB0ygNLTjBPTRDaWxx
+KwSYGp3CIKV6nyYH5x3ATM8xq23TxtDyJCYlYMiXNT9kGSl5o1AD1b6s0ZbC4PUu
+KRLvC1kOL+09oRwlBiYIWTMrKY7K8QIDAQABAoICAAa5ZRdaRozlI3S/6dhDepvm
+aSorFEZpUBI7hLfuHFV5r5Knsi8sW+cwlvEzTCONYdh7qUUIKfU/tfdYQOvhSEe6
+F4osveLCpDAE6ztBfBd4gbC5rZ6I/i2PtL5pJvbNZ+bqULEucaafoaVmtOGhAxnM
+dIlw0iD4vb7Jorh/svD3/UAnId7Q8eswuUPU8zbUBkTzWuu4kj7HAaKgF8TGwkZj
+w1o0dApMgLG6pCw8mzwpDlxiVPnrvIiMxxwRvmBisbw3HtfOLU4AjsfFMxQKNm7n
+wvsRaqCbG4cPAk6JvYTN9R6gcI0r/BKCIfjcOBUPZhvN3T0sna0cXiOyejHQdBL1
+U6KFkasXwzUhT6ciLUibRKqOE+39HwUQTsNL+M7L5G7RpgHdNKW6RwkMNWJJ5hlO
+C/UGbjn4Y224+dtkCzfUDTeaKVgIwGigGhIqLAIaxt1LDeCIZMPSIwoyb1/zagSK
+oCrOyObX6o/ahQqx0TxgwHN0BhWG32WOpGjz8SIiMbz5C9kRyus0It450WmLOSWn
+PUfW4hLaow7VaqeMLe7+kOK6uB4iw7sc2O0Gj9zUh/Uf7erjWGqtaQH9iKp710+S
+XMg6mjI4PEE5hyVMzgwY5vJJQanLMuX24D3FEJdvvb/aT52cvt35ZgsbJl0PIvoy
+qUrgbv79GLmFUsKrygbNAoIBAQDGS+qHk8s5AumAS8JFLCPf8sm5CzEcZteEKwuT
+dMKeYofbpAwOJx7V3kkXJQlQpWtj2zHGKrTzPrzvgDrDiWDgCaDJ/5+GJiWaqOQK
+xC1CRonq2xCMJ9owUJwF20ON/eIJ4aGqjNdKAXU2h/L+R2MhXADN+1/YsGn3CL/o
+s3Aa7tWu4OCE/83e5ZuXW5+PuOTh3m63EdUpUndounvMfiiZkWGnJtRcTB/2bO00
+oezK+Bysc7OV+EBJkvTfQIVduvZvcHOGH5cL/2QXYvtsQbYR2l9eOzoFOQ7aTK+X
+cc+4yWwoptS6Rh2IgcLx5xCYVLFr0zfQXQUbxETCdtyIMLxlAoIBAQDAxdrRMLiG
+IstedCGcBw3aRB1PWM02KQfRFhLyEjzuWld+aPvn1qc3alYQok4N+E+9Pg+jdt/F
+g5JozmOfVaCGF+GweAlNQhwidD46qQsWz5tzPlSz6i3WyPtMwKfQ+Te7n1rkkQ+Y
+Lr1ER+SM+0rwPm40omPB3bGibhYQoVosmgVeMGNDQQruYHaGD1lNotCNZTa1cgMb
+y4SgTFKi2kQKe4ax8pjPt9qAFP41EZEqNXo9JmULrY6Dero/m7x4rjGUEv6xlzrt
+8atb1uCSHJ6GRR/XxPcJWuiuYHy/cnFaQZSR4VrCdeeShhFxCBHB+LtCqQ74B8zf
+dJlGmqbBv62dAoIBAQC2cqUQJzildPt4krvlPy6m39Egk56VHj6PGbfl7Vkft1J/
+EVoSL4ZcitA/HlGKxRig4M3UIfkpkYDu79GhlaXvnIw3Lx4MpM6WlWx0R3nI7/P3
+haWc/xHuwEw9yzdFzuGJ6/L+Y+W17s904/L8aJxZ1jfbTb0rN23X4FIKfgbYkQVE
+iR2q4V3/Bs14ntGZwCm/dBP0FtFE2t6JGoPLbAxY932c+MoNPfFun1xEv/OJ8G0Z
+cr86bhZgW3k4bDoJOnuBnzp7nlcwr8PdDLJ+MZueo4h5wA6rPYtf6Yzpz8qqn5EH
+ejBiTx7fOV0vi0Umk05HAijpapzHpncJYamZGRZNAoIBAFdAdmUetzZHQ2NSDvBP
+JQ74q4eBewibk6UoZ5TXemqry1Q08meh+XeUkrXesJOUI4tVLsDfCjOc9MSpPeAd
+YpWu84DrI9KrLI7PrGbiollFyGdl+/Ke+PZxa4T24j4svvQWEY7ItZU8+n+QRrsk
+9ms85qa+JYbW8BLD3wrR7T2ozOsv3Y3QP8FbOeo9wj7ohZqqCBQiMZQADtx7DyAU
+yJ0yAepDErVZ0vUMC287r0e6gsRwv2WEva92+hvWQn0g4uHRoyQAfjS6oMPlwyl+
++KVvXhVMWkAKvKxIkc4ZX4LpkfRhWrIPqavhML3HWDpCeYeXe2X6KdmuLb4OO5IQ
+TuUCggEBAIQteFXmYESA1couxXRtRAAyq2FVsMa/E/20fs0JzfQ3HYca04HQ588s
+935bxyYmvwGL/OgPlpx8NsyU6Gbh/1ZNH+EWUfP68+ZLbzUioMD2bcSyNuf5PUJj
+PwFuT0KLrxVMh4cG5A1QJzpiP1MAfgLQvzoAaUl+ZsNN7ni1LXfD4GkXc+FznpLH
+owQ12Fr5lp8XZl5T2eIk8hEcqnAvU44gm4s1Pfd1wnVqHc71UOd5saUc6UTjgDbi
+Ss+FgPdnv9svV9F5cueIIhbjnBTxtRsvCIZQUkNCWwW1gen4jMSycGruPq4vMYJ0
+1XUed/WtsZtAhEtxUopFtBuwSGnNjjg=
+-----END PRIVATE KEY-----
+`
+const testAuthTokenId = "my_test_user"
+const testAuthToken = "GwBXoGG5c6NoUTLXnzMxw_uNiVa8PKobzx5EiuylMW0"
+
+var rndStrAlphabet = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 type mockServer struct {
 	ln         net.Listener
 	listenPort int
 }
 
+type mockServerConfig struct {
+	useTLS     bool
+	enableAuth bool
+}
+
 func mockServerStop(ms *mockServer) {
 	ms.ln.Close()
 }
 
-func mockServerStart() *mockServer {
-	ln, err := net.Listen("tcp", ":0")
+func mockServerStart(cfg mockServerConfig) *mockServer {
+	var (
+		ln  net.Listener
+		err error
+	)
+
+	if cfg.useTLS {
+		var cert tls.Certificate
+
+		config := &tls.Config{}
+		cert, err = tls.X509KeyPair([]byte(testTlsCertificate), []byte(testTlsPrivateKey))
+		if err != nil {
+			fatal("Failed to load test cert")
+		}
+		config.Certificates = make([]tls.Certificate, 1)
+		config.Certificates = append(config.Certificates, cert)
+		ln, err = tls.Listen("tcp", ":0", config)
+	} else {
+		ln, err = net.Listen("tcp", ":0")
+	}
 	if err != nil {
 		fatal("Failed to start server listen socket: %s\n", err.Error())
 	}
@@ -35,16 +145,37 @@ func mockServerStart() *mockServer {
 		ln:         ln,
 		listenPort: ln.Addr().(*net.TCPAddr).Port,
 	}
+
 	go func() {
 		for {
-
 			conn, err := ln.Accept()
 			if err != nil {
-				// listen socket is closed
-				return
+				return // socket is closed
 			}
 			go func() {
 				data := make([]byte, 512)
+				if cfg.enableAuth {
+					expectedId := testAuthTokenId + "\n"
+					rc, err := conn.Read(data)
+					if err != nil {
+						fatal("failed to read token id: ", err.Error())
+					}
+					if rc != len(expectedId) {
+						fatal("unexpected token id len: ", expectedId)
+					}
+					actualId := string(data[:rc])
+					if actualId != expectedId {
+						fatal("unexpected token id: ", actualId)
+					}
+
+					_, err = conn.Write([]byte(randStr(512) + "\n"))
+					if err != nil {
+						fatal("failed to write challenge: ", err.Error())
+					}
+
+					// The rest is signature + data
+				}
+
 				for {
 					rc, err := conn.Read(data)
 					if err != nil {
@@ -58,20 +189,28 @@ func mockServerStart() *mockServer {
 			}()
 		}
 	}()
+
 	return ms
 }
 
+func randStr(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = rndStrAlphabet[rand.Intn(len(rndStrAlphabet))]
+	}
+	return string(b)
+}
+
 func TestProcessorInit(t *testing.T) {
-	ms := mockServerStart()
+	ms := mockServerStart(mockServerConfig{})
 	defer mockServerStop(ms)
 	questdbILPBindTo = fmt.Sprintf("127.0.0.1:%d", ms.listenPort)
-	printFn = emptyLog
 	p := &processor{}
-	p.Init(0, false, false)
+	p.Init(0, true, false)
 	p.Close(true)
 
 	p = &processor{}
-	p.Init(1, false, false)
+	p.Init(1, true, false)
 	p.Close(true)
 }
 
@@ -90,12 +229,49 @@ func TestProcessorProcessBatch(t *testing.T) {
 
 	cases := []struct {
 		doLoad bool
+		cfg    mockServerConfig
 	}{
 		{
 			doLoad: false,
+			cfg: mockServerConfig{
+				useTLS:     false,
+				enableAuth: false,
+			},
+		},
+		{
+			doLoad: false,
+			cfg: mockServerConfig{
+				useTLS:     true,
+				enableAuth: false,
+			},
 		},
 		{
 			doLoad: true,
+			cfg: mockServerConfig{
+				useTLS:     false,
+				enableAuth: false,
+			},
+		},
+		{
+			doLoad: true,
+			cfg: mockServerConfig{
+				useTLS:     true,
+				enableAuth: false,
+			},
+		},
+		{
+			doLoad: true,
+			cfg: mockServerConfig{
+				useTLS:     false,
+				enableAuth: true,
+			},
+		},
+		{
+			doLoad: true,
+			cfg: mockServerConfig{
+				useTLS:     true,
+				enableAuth: true,
+			},
 		},
 	}
 
@@ -105,8 +281,17 @@ func TestProcessorProcessBatch(t *testing.T) {
 			fmt.Printf(format, args...)
 		}
 
-		ms := mockServerStart()
+		ms := mockServerStart(c.cfg)
 		questdbILPBindTo = fmt.Sprintf("127.0.0.1:%d", ms.listenPort)
+
+		useTLS = c.cfg.useTLS
+		if c.cfg.enableAuth {
+			authTokenId = testAuthTokenId
+			authToken = testAuthToken
+		} else {
+			authTokenId = ""
+			authToken = ""
+		}
 
 		p := &processor{}
 		p.Init(0, true, true)

--- a/cmd/tsbs_run_queries_questdb/main.go
+++ b/cmd/tsbs_run_queries_questdb/main.go
@@ -6,14 +6,7 @@
 package main
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io/ioutil"
-	"log"
-	"net/http"
-	"net/url"
-	"strings"
 
 	"github.com/blagojts/viper"
 	"github.com/spf13/pflag"
@@ -23,7 +16,9 @@ import (
 
 // Program option vars:
 var (
-	daemonUrls []string
+	restURL  string
+	username string
+	password string
 )
 
 // Global vars:
@@ -35,9 +30,10 @@ var (
 func init() {
 	var config query.BenchmarkRunnerConfig
 	config.AddToFlagSet(pflag.CommandLine)
-	var csvDaemonUrls string
 
-	pflag.String("urls", "http://localhost:9000/", "Daemon URLs, comma-separated. Will be used in a round-robin fashion.")
+	pflag.String("url", "http://localhost:9000/", "Server URL. In case of HTTPS, the client will not validate the certificate, i.e. it trusts any server")
+	pflag.String("username", "", "Basic auth username")
+	pflag.String("password", "", "Basic auth password")
 
 	pflag.Parse()
 
@@ -51,21 +47,9 @@ func init() {
 		panic(fmt.Errorf("unable to decode config: %s", err))
 	}
 
-	csvDaemonUrls = viper.GetString("urls")
-
-	daemonUrls = strings.Split(csvDaemonUrls, ",")
-	if len(daemonUrls) == 0 {
-		log.Fatal("missing 'urls' flag")
-	}
-
-	// Add an index to the hostname column in the cpu table
-	r, err := execQuery(daemonUrls[0], "SHOW COLUMN FROM cpu;")
-	if err == nil && r.Count != 0 {
-		_, err := execQuery(daemonUrls[0], "ALTER TABLE cpu ALTER COLUMN hostname ADD INDEX;")
-		if err == nil {
-			fmt.Println("Added index to hostname column of cpu table")
-		}
-	}
+	restURL = viper.GetString("url")
+	username = viper.GetString("username")
+	password = viper.GetString("password")
 
 	runner = query.NewBenchmarkRunner(config)
 }
@@ -83,11 +67,12 @@ func newProcessor() query.Processor { return &processor{} }
 
 func (p *processor) Init(workerNumber int) {
 	p.opts = &HTTPClientDoOptions{
+		Username:             username,
+		Password:             password,
 		Debug:                runner.DebugLevel(),
 		PrettyPrintResponses: runner.DoPrintResponses(),
 	}
-	url := daemonUrls[workerNumber%len(daemonUrls)]
-	p.w = NewHTTPClient(url)
+	p.w = NewHTTPClient(restURL)
 }
 
 func (p *processor) ProcessQuery(q query.Query, _ bool) ([]*query.Stat, error) {
@@ -99,42 +84,4 @@ func (p *processor) ProcessQuery(q query.Query, _ bool) ([]*query.Stat, error) {
 	stat := query.GetStat()
 	stat.Init(q.HumanLabelName(), lag)
 	return []*query.Stat{stat}, nil
-}
-
-type QueryResponseColumns struct {
-	Name string
-	Type string
-}
-
-type QueryResponse struct {
-	Query   string
-	Columns []QueryResponseColumns
-	Dataset []interface{}
-	Count   int
-	Error   string
-}
-
-func execQuery(uriRoot string, query string) (QueryResponse, error) {
-	var qr QueryResponse
-	if strings.HasSuffix(uriRoot, "/") {
-		uriRoot = uriRoot[:len(uriRoot)-1]
-	}
-	uriRoot = uriRoot + "/exec?query=" + url.QueryEscape(query)
-	resp, err := http.Get(uriRoot)
-	if err != nil {
-		return qr, err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return qr, err
-	}
-	err = json.Unmarshal(body, &qr)
-	if err != nil {
-		return qr, err
-	}
-	if qr.Error != "" {
-		return qr, errors.New(qr.Error)
-	}
-	return qr, nil
 }

--- a/cmd/tsbs_run_queries_questdb/main.go
+++ b/cmd/tsbs_run_queries_questdb/main.go
@@ -59,12 +59,9 @@ func init() {
 	}
 
 	// Add an index to the hostname column in the cpu table
-	r, err := execQuery(daemonUrls[0], "show columns from cpu")
+	r, err := execQuery(daemonUrls[0], "SHOW COLUMN FROM cpu;")
 	if err == nil && r.Count != 0 {
-		r, err := execQuery(daemonUrls[0], "ALTER TABLE cpu ALTER COLUMN hostname ADD INDEX")
-		_ = r
-		//	       fmt.Println("error:", err)
-		//	       fmt.Printf("%+v\n", r)
+		_, err := execQuery(daemonUrls[0], "ALTER TABLE cpu ALTER COLUMN hostname ADD INDEX;")
 		if err == nil {
 			fmt.Println("Added index to hostname column of cpu table")
 		}

--- a/docs/questdb.md
+++ b/docs/questdb.md
@@ -2,10 +2,11 @@
 
 QuestDB is a high-performance open-source time series database with SQL as a
 query language with time-oriented extensions. QuestDB implements PostgreSQL wire
-protocol, a REST API, and supports ingestion using InfluxDB line protocol.
+protocol, REST API, and supports ingestion using InfluxDB Line Protocol over TCP.
 
 This guide explains how the data for TSBS is generated along with additional
 flags available when using the data importer (`tsbs_load_questdb`).
+
 **This should be read _after_ the main README.**
 
 ## Data format
@@ -21,10 +22,10 @@ reading is composed of the following:
 - a timestamp for the record
 - a newline character `\n`
 
-An example reading from the `iot` use case looks like the following:
+An example reading from the Dev Ops use case looks like the following:
 
 ```text
-diagnostics,name=truck_3985,fleet=West,driver=Seth,model=H-2,device_version=v1.5 load_capacity=1500,fuel_capacity=150,nominal_fuel_consumption=12,fuel_state=0.8,current_load=482,status=4i 1451609990000000000
+cpu,hostname=host_0,region=eu-central-1,datacenter=eu-central-1a,rack=6,os=Ubuntu15.10,arch=x86,team=SF,service=19,service_version=1,service_environment=test usage_user=58i,usage_system=2i,usage_idle=24i,usage_nice=61i,usage_iowait=22i,usage_irq=63i,usage_softirq=6i,usage_steal=44i,usage_guest=80i,usage_guest_nice=38i 1451606400000000000
 ```
 
 ## `tsbs_load_questdb` additional flags
@@ -45,48 +46,40 @@ Prints available flags and their defaults:
 tsbs_load_questdb --help
 ```
 
-## How to run the test (FreeBSD example)
+## How to run the test (Linux example)
 
 Firstly, install and build the benchmark suite
 
 ### Set up TSBS
 
-Create a temporary directory for the Go binaries
-
-```bash
-mkdir -p ~/tmp/go/src/github.com/timescale/
-cd ~/tmp/go/src/github.com/timescale/
-```
-
-Clone the TSBS repository, build test and install Go binaries:
+Clone the TSBS repository and build it:
 
 ```bash
 git clone git@github.com:questdb/tsbs.git
-cd ~/tmp/go/src/github.com/timescale/tsbs/ && git checkout questdb-tsbs-load-new
-GOPATH=~/tmp/go go build -v ./...
-GOPATH=~/tmp/go go test -v github.com/timescale/tsbs/cmd/tsbs_load_questdb
-GOPATH=~/tmp/go go install -v ./...
+cd ./tsbs/
+make
+cd ./bin/
 ```
 
 ### Generating data
 
-Data is generated using the `influx` format. To generate a small dataset for
+Data is generated using the `questdb` format. To generate a small dataset for
 quick benchmarks:
 
 ```bash
-~/tmp/go/bin/tsbs_generate_data \
---use-case="cpu-only" --seed=123 --scale=4000 \
---timestamp-start="2016-01-01T00:00:00Z" --timestamp-end="2016-01-01T01:00:00Z" \
---log-interval="10s" --format="influx" > /tmp/data
+./tsbs_generate_data \
+  --use-case="cpu-only" --seed=123 --scale=4000 \
+  --timestamp-start="2016-01-01T00:00:00Z" --timestamp-end="2016-01-01T01:00:00Z" \
+  --log-interval="10s" --format="questdb" > /tmp/data
 ```
 
 To generate a full data set for more intensive benchmarks:
 
 ```bash
-tsbs_generate_data \
---use-case="cpu-only" --seed=123 --scale=4000 \
---timestamp-start="2016-01-01T00:00:00Z" --timestamp-end="2016-01-02T00:00:00Z" \
---log-interval="10s" --format="influx" > /tmp/data
+./tsbs_generate_data \
+  --use-case="cpu-only" --seed=123 --scale=4000 \
+  --timestamp-start="2016-01-01T00:00:00Z" --timestamp-end="2016-01-02T00:00:00Z" \
+  --log-interval="10s" --format="questdb" > /tmp/data
 ```
 
 ### Running the benchmark tool
@@ -94,28 +87,10 @@ tsbs_generate_data \
 Generated data can be loaded directly using the tool:
 
 ```bash
-~/tmp/go/bin/tsbs_load_questdb --file /tmp/data --workers 4
+./tsbs_load_questdb --file /tmp/data --workers 4
 ```
 
-The benchmark tool supports InfluxDB Line Protocol authentication as well as TLS
-encryption:
-```bash
-~/tmp/go/bin/tsbs_load_questdb --file /tmp/data --tls --ilp-auth-id "my_user" --ilp-auth-token "GwBXoGG5c6NoUTLXnzMxw_uNiVa8PKobzx5EiuylMW0" --workers 4
-```
-
-Alternatively, shell scripts are provided which can be used to generate and load
-data:
-
-```bash
-cd ~/tmp/go/src/github.com/timescale/tsbs
-
-# generates data file /tmp/bulk_data/influx-data.gz
-PATH=${PATH}:~/tmp/go/bin FORMATS=influx TS_END=2016-01-01T02:00:00Z bash ./scripts/generate_data.sh
-# load data into QuestDB
-PATH=${PATH}:~/tmp/go/bin NUM_WORKERS=1 ./scripts/load/load_questdb.sh
-```
-
-### Query benchmarks for iot data set (single-groupby-5-8-1 type)
+### Query benchmarks for Dev Ops data set (single-groupby-5-8-1 type)
 
 Queries are generated using the `questdb` format.
 
@@ -125,18 +100,18 @@ The dataset used to run the queries is created with the following commands for
 `single-groupby-5-8-1`:
 
 ```bash
-cd ~/tmp/go/src/github.com/timescale/
+cd ~/tmp/go/src/github.com/questdb/
 
-~/tmp/go/bin/tsbs_generate_queries \
---use-case="cpu-only" --seed=123 --scale=4000 \
---timestamp-start="2016-01-01T00:00:00Z" --timestamp-end="2016-01-02T00:00:01Z" \
---queries=1000 --query-type="single-groupby-5-8-1" \
---format="questdb" > /tmp/queries_questdb
+./tsbs_generate_queries \
+  --use-case="cpu-only" --seed=123 --scale=4000 \
+  --timestamp-start="2016-01-01T00:00:00Z" --timestamp-end="2016-01-02T00:00:01Z" \
+  --queries=1000 --query-type="single-groupby-5-8-1" \
+  --format="questdb" > /tmp/queries_questdb
 
-~/tmp/go/bin/tsbs_run_queries_questdb --file /tmp/queries_questdb --print-interval 500
+./tsbs_run_queries_questdb --file /tmp/queries_questdb --print-interval 500
 ```
 
-### Query benchmarks for iot data set (high-cpu-1 use case)
+### Query benchmarks for Dev Ops data set (high-cpu-1 use case)
 
 Queries are generated using the `questdb` format.
 
@@ -146,23 +121,31 @@ The dataset used to run the queries is created with the following commands for
 `high-cpu-1`:
 
 ```bash
-cd ~/tmp/go/src/github.com/timescale/
+cd ~/tmp/go/src/github.com/questdb/
 
-~/tmp/go/bin/tsbs_generate_queries \
---use-case="cpu-only" --seed=123 --scale=4000 \
---timestamp-start="2016-01-01T00:00:00Z" --timestamp-end="2016-01-02T00:00:01Z" \
---queries=1000 --query-type="high-cpu-1" --format="questdb" > /tmp/queries_questdb
+./tsbs_generate_queries \
+  --use-case="cpu-only" --seed=123 --scale=4000 \
+  --timestamp-start="2016-01-01T00:00:00Z" --timestamp-end="2016-01-02T00:00:01Z" \
+  --queries=1000 --query-type="high-cpu-1" --format="questdb" > /tmp/queries_questdb
 
-~/tmp/go/bin/tsbs_run_queries_questdb --file /tmp/queries_questdb --print-interval 500
+./tsbs_run_queries_questdb --file /tmp/queries_questdb --print-interval 500
 ```
 
-### Query benchmark shell scripts
+### TLS and authentication support
 
-Additionally, shell scripts are provided which can be used to generate and run
-the queries:
-
+The ingestion benchmark tool supports InfluxDB Line Protocol authentication as
+well as TLS encryption:
 ```bash
-cd ~/tmp/go/src/github.com/timescale/
-PATH=${PATH}:~/tmp/go/bin FORMATS=questdb TS_END=2016-01-02T00:00:00Z bash ./scripts/generate_queries.sh
-PATH=${PATH}:~/tmp/go/bin ./scripts/run_queries/run_queries_questdb.sh
+./tsbs_load_questdb --file /tmp/data --workers 4 \
+  --tls \
+  --ilp-auth-id "my_user" \
+  --ilp-auth-token "GwBXoGG5c6NoUTLXnzMxw_uNiVa8PKobzx5EiuylMW0"
+```
+
+The query benchmark tool also supports basic HTTP authentication and TLS encryption:
+```bash
+./tsbs_run_queries_questdb --file /tmp/queries_questdb \
+  --url "https://localhost:9000" \
+  --username user \
+  --password quest
 ```

--- a/docs/questdb.md
+++ b/docs/questdb.md
@@ -97,6 +97,12 @@ Generated data can be loaded directly using the tool:
 ~/tmp/go/bin/tsbs_load_questdb --file /tmp/data --workers 4
 ```
 
+The benchmark tool supports InfluxDB Line Protocol authentication as well as TLS
+encryption:
+```bash
+~/tmp/go/bin/tsbs_load_questdb --file /tmp/data --tls --ilp-auth-id "my_user" --ilp-auth-token "GwBXoGG5c6NoUTLXnzMxw_uNiVa8PKobzx5EiuylMW0" --workers 4
+```
+
 Alternatively, shell scripts are provided which can be used to generate and load
 data:
 

--- a/docs/questdb.md
+++ b/docs/questdb.md
@@ -138,8 +138,8 @@ well as TLS encryption:
 ```bash
 ./tsbs_load_questdb --file /tmp/data --workers 4 \
   --tls \
-  --ilp-auth-id "my_user" \
-  --ilp-auth-token "GwBXoGG5c6NoUTLXnzMxw_uNiVa8PKobzx5EiuylMW0"
+  --auth-id "my_user" \
+  --auth-token "GwBXoGG5c6NoUTLXnzMxw_uNiVa8PKobzx5EiuylMW0"
 ```
 
 The query benchmark tool also supports basic HTTP authentication and TLS encryption:


### PR DESCRIPTION
Closes https://github.com/questdb/questdb/issues/3776

Adds authentication support and TLS encryption for InfluxDB Line Protocol and HTTP.

Also, removes redundant table existence checks and index addition in the benchmarks and updates the docs.